### PR TITLE
Update: README.md, variable name, enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,9 @@ The xontrib will get loaded automatically.
 Store your passwords in [1Password](https://1password.com/) and setup [`op` CLI](https://developer.1password.com/docs/cli/) locally.
 Then:
 ```xsh
-$XONTRIB_ONEPASS_ENABLED = True
 $MYKEY = OnePass("op://path/my/key")
 $MYKEY
 # My key value.
-
-$XONTRIB_ONEPASS_ENABLED = False
-$MYKEY
-# op://path/my/key
 ```
 
 ## Examples
@@ -38,11 +33,18 @@ $MYKEY
 
 ## Good to know
 
-### Disable autoloading
+### Disabling
 
+To disable autoloading:
 ```xsh
 $XONTRIBS_AUTOLOAD_DISABLED = ["1password", ]
-# if you have set this for other xontribs, you should append the value
+```
+To turn off:
+```xsh
+$XONTRIB_1PASSWORD_ENABLED = False
+$MYKEY = OnePass("op://path/my/key")
+$MYKEY
+# op://path/my/key
 ```
 
 ### Get certain key

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ Then:
 ```xsh
 mykey = OnePass("op://path/my/key")
 echo @(mykey)
-# My key value.
+# my-key-value
 
 $MYKEY = OnePass("op://path/my/key")
 echo $MYKEY
-# My key value.
+# my-key-value
+
+env | grep MYKEY
+# MYKEY=my-key-value
 ```
 
 ## Good to know

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ op item get OpenAI-API-Key --format json | jq '.fields[] | select(.type == "CONC
 # "api-key"
 ```
 
+### Debug mode
+
+```xsh
+$XONTRIB_1PASSWORD_DEBUG = True
+```
+
 ## Known issues
 
 ### Alpha version

--- a/README.md
+++ b/README.md
@@ -1,35 +1,10 @@
 <p align="center">
-1password support for xonsh
+<a href="https://1password.com/">1password</a> support for xonsh shell. This approach ensures your sensitive information remains secure while being easily accessible in your xonsh shell.
 </p>
 
 <p align="center">
 If you like the idea click ⭐ on the repo and <a href="https://twitter.com/intent/tweet?text=Nice%20xontrib%20for%20the%20xonsh%20shell!&url=https://github.com/drmikecrowe/xontrib-1password" target="_blank">tweet</a>.
 </p>
-
-> **ALPHA**:  This is the initial release.  Issues/pull requests are welcome.
-
-## Introduction
-
-This xontrib adds support for 1Password secrets to the xonsh shell by utilizing the [op (1password CLI)](https://developer.1password.com/docs/cli/). It works by allowing you to securely store and access your passwords in 1Password. To use:
-
-1. Store your passwords in 1Password.
-2. In your xonsh environment, reference the passwords using the OnePass function:
-```xsh
-$OPENAI_API_KEY = OnePass("op://Private/OpenAI-API-Key/api-key")
-```
-3. To expose the variables in your environment, set:
-```xsh
-$ONEPASS_ENABLED = 1
-```
-
-This approach ensures your sensitive information remains secure while being easily accessible in your xonsh shell.  The URL is basically: `op://<Vault>/<title>/<field>`.  To find this, here's the commands I used to determine these fields:
-
-```sh
-op item list --format json | jq '.[].title | select(. | contains("OpenAI"))' 
-# "OpenAI-API-Key"
-op item get OpenAI-API-Key --format json | jq '.fields[] | select(.type == "CONCEALED") | .label'
-# "api-key"
-```
 
 ## Installation
 
@@ -40,26 +15,52 @@ xpip install xontrib-1password
 # or: xpip install -U git+https://github.com/drmikecrowe/xontrib-1password
 ```
 
+The xontrib will get loaded automatically.
+
 ## Usage
 
+Store your passwords in [1Password](https://1password.com/) and setup [`op` CLI](https://developer.1password.com/docs/cli/) locally.
+Then:
+```xsh
+$XONTRIB_ONEPASS_ENABLED = True
+$MYKEY = OnePass("op://path/my/key")
+$MYKEY
+# My key value.
 
-This xontrib will get loaded automatically for interactive sessions.
+$XONTRIB_ONEPASS_ENABLED = False
+$MYKEY
+# op://path/my/key
+```
 
-To disable autoloading:
+## Examples
+
+![Example](./1password-example.png)
+
+## Good to know
+
+### Disable autoloading
 
 ```xsh
 $XONTRIBS_AUTOLOAD_DISABLED = ["1password", ]
 # if you have set this for other xontribs, you should append the value
 ```
 
+### Get certain key
 
-## Examples
+Because of the URL is basically `op://<Vault>/<title>/<field>` to find this, here's the commands you can use to determine these fields:
 
-![Example](./1password-example.png)
+```sh
+op item list --format json | jq '.[].title | select(. | contains("OpenAI"))' 
+# "OpenAI-API-Key"
+op item get OpenAI-API-Key --format json | jq '.fields[] | select(.type == "CONCEALED") | .label'
+# "api-key"
+```
 
 ## Known issues
 
-None
+### Alpha version
+
+This is the initial release of the xontrib. Issues and pull requests are welcome.
 
 ## Development
 
@@ -70,8 +71,7 @@ pre-commit install
 pre-commit autoupdate
 ```
 
-
-## Releasing your package
+### Releasing your package
 
 - Bump the version of your package.
 - Create a GitHub release (The release notes are automatically generated as a draft release after each push).

--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ $MYKEY
 # My key value.
 ```
 
-## Examples
-
-![Example](./1password-example.png)
-
 ## Good to know
 
 ### Disabling

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ You can set `$XONTRIB_1PASSWORD_CACHE` to string:
   
 ## Known issues
 
-### Alpha version
+### Slowing down reading environment variables
 
-This is the initial release of the xontrib. Issues and pull requests are welcome.
+If you disable cache (i.e. `$XONTRIB_1PASSWORD_CACHE='off'`) in case of `$MYVAR = OnePass(...)` every time the shell read the env variables list the value will be requested from OnePassword and it takes time.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ The xontrib will get loaded automatically.
 Store your passwords in [1Password](https://1password.com/) and setup [`op` CLI](https://developer.1password.com/docs/cli/) locally.
 Then:
 ```xsh
+mykey = OnePass("op://path/my/key")
+echo @(mykey)
+# My key value.
+
 $MYKEY = OnePass("op://path/my/key")
-$MYKEY
+echo $MYKEY
 # My key value.
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ op item get OpenAI-API-Key --format json | jq '.fields[] | select(.type == "CONC
 $XONTRIB_1PASSWORD_DEBUG = True
 ```
 
+### Cache
+
+You can set `$XONTRIB_1PASSWORD_CACHE` to string:
+* `not_empty` (default) - cache not empty values.
+* `all` - cache all values.
+* `off` - disable caching.
+  
 ## Known issues
 
 ### Alpha version

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -12,7 +12,7 @@ class OnePass:
         return self.__repr__()
 
     def __repr__(self):
-        if __xonsh__.env.get("XONTRIB_ONEPASS_ENABLED", True):
+        if __xonsh__.env.get("XONTRIB_1PASSWORD_ENABLED", True):
             if self.url not in cache:
                 result = subprocess.run(
                     ["op", "read", self.url], capture_output=True, text=True

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -41,3 +41,4 @@ class OnePass:
         value = result.stdout.strip()
         if result.stderr:
             print(f"xontrib-1password: {url!r}: {result.stderr}", file=sys.stderr)
+        return value

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -12,7 +12,7 @@ class OnePass:
         return self.__repr__()
 
     def __repr__(self):
-        if __xonsh__.env.get("XONTRIB_ONEPASS_ENABLED", False):
+        if __xonsh__.env.get("XONTRIB_ONEPASS_ENABLED", True):
             if self.url not in cache:
                 result = subprocess.run(
                     ["op", "read", self.url], capture_output=True, text=True

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -19,23 +19,26 @@ class OnePass:
     def __repr__(self):
         if __xonsh__.env.get("XONTRIB_1PASSWORD_ENABLED", True):
             if self.url not in _1password_cache:
-                result = subprocess.run(
-                    ["op", "read", self.url], capture_output=True, text=True
-                )
+                result = subprocess.run(["op", "read", self.url], capture_output=True, text=True)
                 key = result.stdout.strip()
-                print(
-                    "Your 1Password environmental secret "
-                    f"{self.url} is live in your environment",
-                    file=sys.stderr,
-                )
+                if result.stderr:
+                    print(f"xontrib-1password error for {self.url!r}: {result.stderr}", file=sys.stderr)
+
+                if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):
+                    print(
+                        "Your 1Password environmental secret "
+                        f"{self.url} is live in your environment",
+                        file=sys.stderr,
+                    )
                 _1password_cache[self.url] = key
             return _1password_cache[self.url]
         else:
             if self.url in _1password_cache:
-                print(
-                    "Your 1Password environmental secret "
-                    f"{self.url} is no longer in your environment",
-                    file=sys.stderr,
-                )
+                if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):
+                    print(
+                        "Your 1Password environmental secret "
+                        f"{self.url} is no longer in your environment",
+                        file=sys.stderr,
+                    )
                 del _1password_cache[self.url]
             return self.url

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -1,6 +1,11 @@
 import subprocess
 import sys
 
+
+if not __xonsh__.imp.shutil.which('op'):
+    print('xontrib-1password: OnePassword CLI tool not found. Install: https://developer.1password.com/docs/cli/get-started/', file=sys.stderr)
+
+
 cache = {}
 
 

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -17,10 +17,11 @@ class OnePass:
         return self.__repr__()
 
     def __repr__(self):
+        cache = __xonsh__.env.get("XONTRIB_1PASSWORD_CACHE", "not_empty")
         if __xonsh__.env.get("XONTRIB_1PASSWORD_ENABLED", True):
             if self.url not in _1password_cache:
                 result = subprocess.run(["op", "read", self.url], capture_output=True, text=True)
-                key = result.stdout.strip()
+                value = result.stdout.strip()
                 if result.stderr:
                     print(f"xontrib-1password error for {self.url!r}: {result.stderr}", file=sys.stderr)
 
@@ -30,8 +31,9 @@ class OnePass:
                         f"{self.url} is live in your environment",
                         file=sys.stderr,
                     )
-                _1password_cache[self.url] = key
-            return _1password_cache[self.url]
+                if cache == "all" or (cache == "not_empty" and value):
+                    _1password_cache[self.url] = value
+            return value
         else:
             if self.url in _1password_cache:
                 if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -23,24 +23,16 @@ class OnePass:
                 result = subprocess.run(["op", "read", self.url], capture_output=True, text=True)
                 value = result.stdout.strip()
                 if result.stderr:
-                    print(f"xontrib-1password error for {self.url!r}: {result.stderr}", file=sys.stderr)
+                    print(f"xontrib-1password: {self.url!r}: {result.stderr}", file=sys.stderr)
 
-                if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):
-                    print(
-                        "Your 1Password environmental secret "
-                        f"{self.url} is live in your environment",
-                        file=sys.stderr,
-                    )
                 if cache == "all" or (cache == "not_empty" and value):
+                    if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):
+                        print(f"xontrib-1password: added {self.url!r} value to cache", file=sys.stderr)
                     _1password_cache[self.url] = value
             return value
         else:
             if self.url in _1password_cache:
                 if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):
-                    print(
-                        "Your 1Password environmental secret "
-                        f"{self.url} is no longer in your environment",
-                        file=sys.stderr,
-                    )
+                    print(f"xontrib-1password: removed {self.url!r} value from cache.", file=sys.stderr)
                 del _1password_cache[self.url]
             return self.url

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -17,18 +17,17 @@ class OnePass:
         return self.__repr__()
 
     def __repr__(self):
-        cache = __xonsh__.env.get("XONTRIB_1PASSWORD_CACHE", "not_empty")
         if __xonsh__.env.get("XONTRIB_1PASSWORD_ENABLED", True):
-            if self.url not in _1password_cache:
-                result = subprocess.run(["op", "read", self.url], capture_output=True, text=True)
-                value = result.stdout.strip()
-                if result.stderr:
-                    print(f"xontrib-1password: {self.url!r}: {result.stderr}", file=sys.stderr)
+            cache = __xonsh__.env.get("XONTRIB_1PASSWORD_CACHE", "not_empty")
+            if self.url in _1password_cache and cache not in ['off', False]:
+                return _1password_cache[self.url]
 
-                if cache == "all" or (cache == "not_empty" and value):
-                    if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):
-                        print(f"xontrib-1password: added {self.url!r} value to cache", file=sys.stderr)
-                    _1password_cache[self.url] = value
+            value = self.op_read(self.url)
+            
+            if cache == "all" or (cache == "not_empty" and value):
+                if __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):
+                    print(f"xontrib-1password: added {self.url!r} value to cache", file=sys.stderr)
+                _1password_cache[self.url] = value
             return value
         else:
             if self.url in _1password_cache:
@@ -36,3 +35,9 @@ class OnePass:
                     print(f"xontrib-1password: removed {self.url!r} value from cache.", file=sys.stderr)
                 del _1password_cache[self.url]
             return self.url
+
+    def op_read(self, url):
+        result = subprocess.run(["op", "read", url], capture_output=True, text=True)
+        value = result.stdout.strip()
+        if result.stderr:
+            print(f"xontrib-1password: {url!r}: {result.stderr}", file=sys.stderr)

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -6,7 +6,7 @@ if not __xonsh__.imp.shutil.which('op'):
     print('xontrib-1password: OnePassword CLI tool not found. Install: https://developer.1password.com/docs/cli/get-started/', file=sys.stderr)
 
 
-cache = {}
+_1password_cache = {}
 
 
 class OnePass:
@@ -18,7 +18,7 @@ class OnePass:
 
     def __repr__(self):
         if __xonsh__.env.get("XONTRIB_1PASSWORD_ENABLED", True):
-            if self.url not in cache:
+            if self.url not in _1password_cache:
                 result = subprocess.run(
                     ["op", "read", self.url], capture_output=True, text=True
                 )
@@ -28,14 +28,14 @@ class OnePass:
                     f"{self.url} is live in your environment",
                     file=sys.stderr,
                 )
-                cache[self.url] = key
-            return cache[self.url]
+                _1password_cache[self.url] = key
+            return _1password_cache[self.url]
         else:
-            if self.url in cache:
+            if self.url in _1password_cache:
                 print(
                     "Your 1Password environmental secret "
                     f"{self.url} is no longer in your environment",
                     file=sys.stderr,
                 )
-                del cache[self.url]
+                del _1password_cache[self.url]
             return self.url

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -12,7 +12,7 @@ class OnePass:
         return self.__repr__()
 
     def __repr__(self):
-        if __xonsh__.env.get("ONEPASS_ENABLED", False):
+        if __xonsh__.env.get("XONTRIB_ONEPASS_ENABLED", False):
             if self.url not in cache:
                 result = subprocess.run(
                     ["op", "read", self.url], capture_output=True, text=True


### PR DESCRIPTION
Hey! Thank you for this xontrib!

* Added warning about installation `op` tool.
* Added `$XONTRIB_1PASSWORD_DEBUG` to hide unwanted messages.
* Added showing stderr.
* Added `$XONTRIB_1PASSWORD_CACHE`.
* Updated README: more strict structure.
* Updated `XONTRIB_1PASSWORD_ENABLED`: True by default.
* Renamed `ONEPASS_ENABLED` to `XONTRIB_1PASSWORD_ENABLED`: it's highly recommended.
* Renamed `cache` to `_1password_cache` to have clear global.

It will be good to release 0.2.0 with this.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
