### PR TITLE
fix: Respect environment updates from run control (RC) files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.9.2"
+    rev: "v0.12.2"
     hooks:
       - id: ruff
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.14.1" # Use the sha / tag you want to point at
+    rev: "v1.16.1" # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         args: [ "--allow-untyped-globals", "--ignore-missing-imports" ]
@@ -22,7 +22,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: "v4.0.0"
+    rev: "v4.2.0"
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The xontrib will get loaded automatically.
 
 ## Usage
 
+Enable in your [Run Control (RC) file](https://xon.sh/xonshrc.html):
+
+```xsh
+$XONTRIB_1PASSWORD_ENABLED = True
+```
+
 Store your passwords in [1Password](https://1password.com/) and setup [`op` CLI](https://developer.1password.com/docs/cli/) locally.
 Then:
 ```xsh
@@ -55,7 +61,7 @@ $MYKEY
 Because of the URL is basically `op://<Vault>/<title>/<field>` to find this, here's the commands you can use to determine these fields:
 
 ```sh
-op item list --format json | jq '.[].title | select(. | contains("OpenAI"))' 
+op item list --format json | jq '.[].title | select(. | contains("OpenAI"))'
 # "OpenAI-API-Key"
 op item get OpenAI-API-Key --format json | jq '.fields[] | select(.type == "CONCEALED") | .label'
 # "api-key"
@@ -73,7 +79,7 @@ You can set `$XONTRIB_1PASSWORD_CACHE` to string:
 * `not_empty` (default) - cache not empty values.
 * `all` - cache all values.
 * `off` - disable caching.
-  
+
 ## Known issues
 
 ### Slowing down reading environment variables

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The xontrib will get loaded automatically.
 
 ## Usage
 
-Enable in your [Run Control (RC) file](https://xon.sh/xonshrc.html):
+For maximum security, enable your secrets dynamically using the command below when required. You may also enable permanently and expose your secrets at all times in your [Run Control (RC) file](https://xon.sh/xonshrc.html):
 
 ```xsh
 $XONTRIB_1PASSWORD_ENABLED = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xontrib-1password"
-version = "0.3.0"
+version = "0.3.1"
 description = "1password support for xonsh"
 authors = ["Mike Crowe <drmikecrowe@gmail.com>"]
 

--- a/xontrib_1password/__version__.py
+++ b/xontrib_1password/__version__.py
@@ -1,3 +1,3 @@
 """Version information for xontrib-1password."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -81,7 +81,7 @@ class OnePass:
                 f"xontrib-1password: (see /tmp/onepass.env) {result.stderr} ",
                 file=sys.stderr,
             )
-            return
+            return None
         lines = result.stdout.strip().split("\n")
         results = {}
         for line in lines:

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -5,7 +5,7 @@ from xonsh.built_ins import XSH
 
 from xontrib_1password import __version__
 
-if not XSH.imp.shutil.which("op"):  # type: ignore
+if not XSH.imp.shutil.which("op", path=XSH.env.get("PATH")):  # type: ignore
     print(
         "xontrib-1password: OnePassword CLI tool not found. Install: https://developer.1password.com/docs/cli/get-started/",
         file=sys.stderr,

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -74,6 +74,7 @@ class OnePass:
         result = subprocess.run(
             ["op", "inject", "-i", "/tmp/onepass.env"],
             capture_output=True,
+            env=XSH.env,
             text=True,
         )
         if result.stderr:

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -62,7 +62,8 @@ class OnePass:
     def op_read(self) -> dict[str, str] | None:
         """
         Reads all secrets from 1password and returns a dictionary of them.
-        We'll load all secrets from 1password since it's now a single call and there's no additional overhead.
+        We'll load all secrets from 1password since it's now a single call
+        and there's no additional overhead.
         """
         todo = self.all_unloaded_secrets()
         if not todo:

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -1,9 +1,11 @@
 import subprocess
 import sys
 
+from xonsh.built_ins import XSH
+
 from xontrib_1password import __version__
 
-if not __xonsh__.imp.shutil.which("op"):  # type: ignore
+if not XSH.imp.shutil.which("op"):  # type: ignore
     print(
         "xontrib-1password: OnePassword CLI tool not found. Install: https://developer.1password.com/docs/cli/get-started/",
         file=sys.stderr,
@@ -27,25 +29,23 @@ class OnePass:
         return self.__repr__()
 
     def enabled(self):
-        enabled = __xonsh__.env.get("XONTRIB_1PASSWORD_ENABLED", False)  # type: ignore
+        enabled = XSH.env.get("XONTRIB_1PASSWORD_ENABLED", False)  # type: ignore
         return enabled
 
     def cache_mode(self):
-        mode = self.enabled() and __xonsh__.env.get(
-            "XONTRIB_1PASSWORD_CACHE", "not_empty"
-        )  # type: ignore
+        mode = self.enabled() and XSH.env.get("XONTRIB_1PASSWORD_CACHE", "not_empty")  # type: ignore
         return mode
 
     def no_cache_mode(self):
         return self.cache_mode() in ["off", False]
 
     def log(self, *args, **kwargs):
-        if self.enabled() and __xonsh__.env.get("XONTRIB_1PASSWORD_DEBUG", False):  # type: ignore
+        if self.enabled() and XSH.env.get("XONTRIB_1PASSWORD_DEBUG", False):  # type: ignore
             print(*args, **kwargs, file=sys.stderr)
 
     def log_once(self, *args, **kwargs):
         global _notifications
-        if not __xonsh__.env.get("XONTRIB_1PASSWORD_ENABLED", False):  # type: ignore
+        if not XSH.env.get("XONTRIB_1PASSWORD_ENABLED", False):  # type: ignore
             return
         msg = " ".join(args)
         if msg not in _notifications:


### PR DESCRIPTION
## Changes

Addresses https://github.com/drmikecrowe/xontrib-1password/issues/5:

- 95e3c33 docs(readme): Recommend enabling dynamically by default
- 109a2c4 chore(version): Bump patch version
- 2b8701d docs(readme): Demonstrate enabling xontrib in usage section
- 06d83dc refactor(main): Call op executable with Xonsh environment
- 84b44fa fix(main): Find op executable using path from Xonsh environment
- 4a1e6e4 style(main): Address mypy rule, return-value
- 3cd15fe style(main): Address Ruff rule, E501, for line-too-long
- 6926e28 style(main): Address Ruff rule, F821, for undefined-name
- d84cd80 chore(pre-commit): Auto-update repo revisions

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
