### PR TITLE
fix(main): Detype xonsh environment variables for subprocess calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xontrib-1password"
-version = "0.3.1"
+version = "0.3.2"
 description = "1password support for xonsh"
 authors = ["Mike Crowe <drmikecrowe@gmail.com>"]
 

--- a/xontrib_1password/__version__.py
+++ b/xontrib_1password/__version__.py
@@ -1,3 +1,3 @@
 """Version information for xontrib-1password."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/xontrib_1password/main.py
+++ b/xontrib_1password/main.py
@@ -5,7 +5,7 @@ from xonsh.built_ins import XSH
 
 from xontrib_1password import __version__
 
-if not XSH.imp.shutil.which("op", path=XSH.env.get("PATH")):  # type: ignore
+if not XSH.imp.shutil.which("op", path=XSH.env.get_detyped("PATH")):  # type: ignore
     print(
         "xontrib-1password: OnePassword CLI tool not found. Install: https://developer.1password.com/docs/cli/get-started/",
         file=sys.stderr,
@@ -74,7 +74,7 @@ class OnePass:
         result = subprocess.run(
             ["op", "inject", "-i", "/tmp/onepass.env"],
             capture_output=True,
-            env=XSH.env,
+            env=XSH.env.detype_all(),
             text=True,
         )
         if result.stderr:


### PR DESCRIPTION
## Problem

I introduced a bug in #6 by not de-typing environment variables passed to subprocess calls as they expect string values.

```xsh
┬─[~]─[]─()
╰─[1752360434]─@> xonsh
TypeError: expected str, bytes or os.PathLike object, not EnvPath
Failed to load xontrib xontrib_1password.main.
TypeError: expected str, bytes or os.PathLike object, not EnvPath
Failed to load xontrib 1password.
```

## Changes

- 1bd820e chore(version): Bump patch version
- 1112d35 fix(main): Detype xonsh environment variables for subprocess calls

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**